### PR TITLE
Fix: Correct action name in README workflow

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Update README
-        uses: JamesIves/github-activity-readme@v1
+        uses: jamesgeorge007/github-activity-readme@v0.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:


### PR DESCRIPTION
The workflow was failing because the action `jamesives/github-activity-readme` could not be found. This has been corrected to `jamesgeorge007/github-activity-readme@v0.4.5`, which is the new location for the action.